### PR TITLE
Fix Ubuntu system library installation

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,12 +13,6 @@ runs:
     run: |
       UBUNTU_VERSION=$(lsb_release -rs)
 
-      if [ $UBUNTU_VERSION != "18.04" ] && [ $UBUNTU_VERSION != "20.04" ]; then
-          echo "No Swift Toolchain available for Ubuntu version '$UBUNTU_VERSION'."
-          echo "Visit https://swift.org/download for more information."
-          exit 1;
-      fi
-
       echo "UBUNTU_VERSION=$UBUNTU_VERSION" >> $GITHUB_ENV
     shell: bash
 

--- a/install-swift.sh
+++ b/install-swift.sh
@@ -14,9 +14,21 @@ TOOLCHAIN_TAR_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_TAR"
 TOOLCHAIN_SIG_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_SIG"
 
 echo "Installing system dependencies 📦"
-sudo apt-get install \
-binutils git gnupg2 libc6-dev libcurl4 libedit2 libgcc-9-dev libpython2.7 libsqlite3-0 libstdc++-9-dev libxml2 \
-libz3-dev pkg-config tzdata uuid-dev zlib1g-dev
+if [ $UBUNTU_VERSION == "18.04" ]; then
+    echo "choosing list for 18.04"
+    sudo apt-get install \
+    binutils git libc6-dev libcurl4 libedit2 libgcc-5-dev libpython2.7 libsqlite3-0 libstdc++-5-dev libxml2 \
+    pkg-config tzdata zlib1g-dev
+elif [ $UBUNTU_VERSION == "20.04" ]; then
+    echo "choosing list for 20.04"
+    sudo apt-get install \
+    binutils git gnupg2 libc6-dev libcurl4 libedit2 libgcc-9-dev libpython2.7 libsqlite3-0 libstdc++-9-dev libxml2 \
+    libz3-dev pkg-config tzdata uuid-dev zlib1g-dev
+else
+    echo "No Swift Toolchain available for Ubuntu version '$UBUNTU_VERSION'."
+    echo "Visit https://swift.org/download for more information."
+    exit 1;
+fi
 
 if [ -d "/usr/share/swift-toolchain" ]; then
     echo "Toolchain already exists, skipping download ✅"

--- a/install-swift.sh
+++ b/install-swift.sh
@@ -15,7 +15,7 @@ TOOLCHAIN_SIG_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_SIG"
 
 echo "Installing system dependencies 📦"
 sudo apt-get install \
-binutils git gnupg2 libc6-dev libcurl4 libedit2 libgcc-9-dev libpython2.7 libsqlite3-0 libstdc++-9-dev libxml2 \ 
+binutils git gnupg2 libc6-dev libcurl4 libedit2 libgcc-9-dev libpython2.7 libsqlite3-0 libstdc++-9-dev libxml2 \
 libz3-dev pkg-config tzdata uuid-dev zlib1g-dev
 
 if [ -d "/usr/share/swift-toolchain" ]; then
@@ -39,5 +39,5 @@ else
     echo "Successfully installed Swift toolchain 🎉"
 fi
 
-export PATH=/usr/share/swift-toolchain/usr/bin:${PATH} 
+export PATH=/usr/share/swift-toolchain/usr/bin:${PATH}
 echo "PATH=$PATH" >> $GITHUB_ENV

--- a/install-swift.sh
+++ b/install-swift.sh
@@ -13,14 +13,13 @@ TOOLCHAIN_SIG="$TOOLCHAIN_TAR.sig"
 TOOLCHAIN_TAR_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_TAR"
 TOOLCHAIN_SIG_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_SIG"
 
-echo "Installing system dependencies 📦"
+echo "Installing system dependencies for '$UBUNTU_VERSION' 📦"
+sudo apt-get update
 if [ $UBUNTU_VERSION == "18.04" ]; then
-    echo "choosing list for 18.04"
     sudo apt-get install \
     binutils git libc6-dev libcurl4 libedit2 libgcc-5-dev libpython2.7 libsqlite3-0 libstdc++-5-dev libxml2 \
     pkg-config tzdata zlib1g-dev
 elif [ $UBUNTU_VERSION == "20.04" ]; then
-    echo "choosing list for 20.04"
     sudo apt-get install \
     binutils git gnupg2 libc6-dev libcurl4 libedit2 libgcc-9-dev libpython2.7 libsqlite3-0 libstdc++-9-dev libxml2 \
     libz3-dev pkg-config tzdata uuid-dev zlib1g-dev


### PR DESCRIPTION
## Fixes
- Unnecessary trailing whitespace in `apt-get install` command causing `Command not found` error
- Choose depencies based on Ubuntu version