### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
         swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2021-11-12-a]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
-        swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2021-11-12-a]
+        swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ jobs:
     strategy:
       matrix:
         swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2021-11-12-a]
-        ubuntu: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
         fail-fast: false
-    runs-on: ${{ matrix.ubuntu }}
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Install Swift
       uses: slashmo/install-swift@v0.1.0

--- a/action.yaml
+++ b/action.yaml
@@ -45,9 +45,9 @@ runs:
     run: SWIFT_VERSION=${{ inputs.version }} $GITHUB_ACTION_PATH/install-swift.sh
     shell: bash
 
-  # - name: Print Swift Version
-  #   run: swift --version
-  #   shell: bash
+  - name: Print Swift Version
+    run: swift --version
+    shell: bash
 
 branding:
   icon: 'briefcase'

--- a/action.yaml
+++ b/action.yaml
@@ -9,11 +9,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Determine Ubuntu Version
+  - name: Determine Cache Key
     run: |
-      UBUNTU_VERSION=$(lsb_release -rs)
+      # ubuntu-20.04-5.5
+      # macos-12.2-5.5
 
-      echo "UBUNTU_VERSION=$UBUNTU_VERSION" >> $GITHUB_ENV
+      if [ $RUNNER_OS == Linux ]; then
+        PLATFORM_PART=ubuntu-$(lsb_release -rs)
+      elif [ $RUNNER_OS == macOS ]; then
+        PLATFORM_PART=macos-$(sw_vers -ProductVersion)
+      fi
+
+      echo "CACHE_KEY=$PLATFORM_PART-${{ inputs.version }}" >> $GITHUB_ENV
     shell: bash
 
   - name: Cache Swift Toolchain
@@ -21,7 +28,7 @@ runs:
     uses: actions/cache@v2
     with:
       path: /usr/share/swift-toolchain
-      key: ubuntu-${{ env.UBUNTU_VERSION }}-${{ inputs.version }}
+      key: ${{ env.CACHE_KEY }}-${{ inputs.version }}
 
   - name: Install Swift Toolchain
     run: SWIFT_VERSION=${{ inputs.version }} $GITHUB_ACTION_PATH/install-swift.sh

--- a/action.yaml
+++ b/action.yaml
@@ -14,21 +14,32 @@ runs:
       # ubuntu-20.04-5.5
       # macos-12.2-5.5
 
-      if [ $RUNNER_OS == Linux ]; then
-        PLATFORM=ubuntu-$(lsb_release -rs)
-      elif [ $RUNNER_OS == macOS ]; then
-        PLATFORM=macos-$(sw_vers -productVersion)
+      SWIFT_VERSION=${{ inputs.version }}
+
+      if [[ $SWIFT_VERSION == swift-DEVELOPMENT-SNAPSHOT* ]]; then
+          RELEASE_NAME=$SWIFT_VERSION
+      else
+          RELEASE_NAME=swift-$SWIFT_VERSION-RELEASE
       fi
 
-      echo "CACHE_KEY=$PLATFORM-${{ inputs.version }}" >> $GITHUB_ENV
+      if [ $RUNNER_OS == Linux ]; then
+        PLATFORM=ubuntu-$(lsb_release -rs)
+        TOOLCHAIN_PATH=/opt/swift-toolchains/$RELEASE_NAME
+      elif [ $RUNNER_OS == macOS ]; then
+        PLATFORM=macos-$(sw_vers -productVersion)
+        TOOLCHAIN_PATH=/Library/Developer/Toolchains/$RELEASE_NAME.xctoolchain
+      fi
+
+      echo "TOOLCHAIN_PATH=$TOOLCHAIN_PATH" >> $GITHUB_ENV
+      echo "CACHE_KEY=$PLATFORM-$SWIFT_VERSION" >> $GITHUB_ENV
     shell: bash
 
-  # - name: Cache Swift Toolchain
-  #   id: swift-toolchain-cache
-  #   uses: actions/cache@v2
-  #   with:
-  #     path: /opt/swift-toolchains/${{ inputs.version }}.xctoolchain
-  #     key: ${{ env.CACHE_KEY }}
+  - name: Cache Swift Toolchain
+    id: swift-toolchain-cache
+    uses: actions/cache@v2
+    with:
+      path: ${{ env.TOOLCHAIN_PATH }}
+      key: ${{ env.CACHE_KEY }}
 
   - name: Install Swift Toolchain
     run: SWIFT_VERSION=${{ inputs.version }} $GITHUB_ACTION_PATH/install-swift.sh

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-  - name: Determine Cache Key
+  - name: Determine Cache Options
     run: |
       # ubuntu-20.04-5.5
       # macos-12.2-5.5
@@ -24,13 +24,13 @@ runs:
 
       if [ $RUNNER_OS == Linux ]; then
         PLATFORM=ubuntu-$(lsb_release -rs)
-        TOOLCHAIN_PATH=/opt/swift-toolchains/$RELEASE_NAME
+        TOOLCHAIN_CACHE_PATH=/opt/swift-toolchains/$RELEASE_NAME
       elif [ $RUNNER_OS == macOS ]; then
         PLATFORM=macos-$(sw_vers -productVersion)
-        TOOLCHAIN_PATH=${HOME}/Library/Developer/Toolchains/$RELEASE_NAME.xctoolchain
+        TOOLCHAIN_CACHE_PATH=${HOME}/Library/Developer/Toolchains/$RELEASE_NAME.xctoolchain
       fi
 
-      echo "TOOLCHAIN_PATH=$TOOLCHAIN_PATH" >> $GITHUB_ENV
+      echo "TOOLCHAIN_CACHE_PATH=$TOOLCHAIN_CACHE_PATH" >> $GITHUB_ENV
       echo "CACHE_KEY=$PLATFORM-$SWIFT_VERSION" >> $GITHUB_ENV
     shell: bash
 
@@ -38,8 +38,8 @@ runs:
     id: swift-toolchain-cache
     uses: actions/cache@v2
     with:
-      path: ${{ env.TOOLCHAIN_PATH }}
-      key: ${{ env.CACHE_KEY }}
+      path: ${{ env.TOOLCHAIN_CACHE_PATH }}
+      key: ${{ env.TOOLCHAIN_CACHE_KEY }}
 
   - name: Install Swift Toolchain
     run: SWIFT_VERSION=${{ inputs.version }} $GITHUB_ACTION_PATH/install-swift.sh

--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ runs:
       fi
 
       echo "TOOLCHAIN_CACHE_PATH=$TOOLCHAIN_CACHE_PATH" >> $GITHUB_ENV
-      echo "CACHE_KEY=$PLATFORM-$SWIFT_VERSION" >> $GITHUB_ENV
+      echo "TOOLCHAIN_CACHE_KEY=$PLATFORM-$SWIFT_VERSION" >> $GITHUB_ENV
     shell: bash
 
   - name: Cache Swift Toolchain

--- a/action.yaml
+++ b/action.yaml
@@ -15,20 +15,20 @@ runs:
       # macos-12.2-5.5
 
       if [ $RUNNER_OS == Linux ]; then
-        PLATFORM_PART=ubuntu-$(lsb_release -rs)
+        PLATFORM=ubuntu-$(lsb_release -rs)
       elif [ $RUNNER_OS == macOS ]; then
-        PLATFORM_PART=macos-$(sw_vers -ProductVersion)
+        PLATFORM=macos-$(sw_vers -productVersion)
       fi
 
-      echo "CACHE_KEY=$PLATFORM_PART-${{ inputs.version }}" >> $GITHUB_ENV
+      echo "CACHE_KEY=$PLATFORM-${{ inputs.version }}" >> $GITHUB_ENV
     shell: bash
 
-  - name: Cache Swift Toolchain
-    id: swift-toolchain-cache
-    uses: actions/cache@v2
-    with:
-      path: /usr/share/swift-toolchain
-      key: ${{ env.CACHE_KEY }}-${{ inputs.version }}
+  # - name: Cache Swift Toolchain
+  #   id: swift-toolchain-cache
+  #   uses: actions/cache@v2
+  #   with:
+  #     path: /opt/swift-toolchains/${{ inputs.version }}.xctoolchain
+  #     key: ${{ env.CACHE_KEY }}
 
   - name: Install Swift Toolchain
     run: SWIFT_VERSION=${{ inputs.version }} $GITHUB_ACTION_PATH/install-swift.sh

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,7 @@ runs:
         TOOLCHAIN_PATH=/opt/swift-toolchains/$RELEASE_NAME
       elif [ $RUNNER_OS == macOS ]; then
         PLATFORM=macos-$(sw_vers -productVersion)
-        TOOLCHAIN_PATH=/Library/Developer/Toolchains/$RELEASE_NAME.xctoolchain
+        TOOLCHAIN_PATH=${HOME}/Library/Developer/Toolchains/$RELEASE_NAME.xctoolchain
       fi
 
       echo "TOOLCHAIN_PATH=$TOOLCHAIN_PATH" >> $GITHUB_ENV
@@ -45,9 +45,9 @@ runs:
     run: SWIFT_VERSION=${{ inputs.version }} $GITHUB_ACTION_PATH/install-swift.sh
     shell: bash
 
-  - name: Print Swift Version
-    run: swift --version
-    shell: bash
+  # - name: Print Swift Version
+  #   run: swift --version
+  #   shell: bash
 
 branding:
   icon: 'briefcase'

--- a/install-swift.sh
+++ b/install-swift.sh
@@ -1,54 +1,122 @@
 #!/bin/bash
 
-if [[ $SWIFT_VERSION == swift-DEVELOPMENT-SNAPSHOT* ]]; then
-    TOOLCHAIN_BASE_URL="https://download.swift.org/development/ubuntu${UBUNTU_VERSION//[.]/}/$SWIFT_VERSION"
-    TOOLCHAIN_PATH="$SWIFT_VERSION-ubuntu$UBUNTU_VERSION"
-else
-    TOOLCHAIN_BASE_URL="https://download.swift.org/swift-$SWIFT_VERSION-release/ubuntu${UBUNTU_VERSION//[.]/}/swift-$SWIFT_VERSION-RELEASE"
-    TOOLCHAIN_PATH="swift-$SWIFT_VERSION-RELEASE-ubuntu$UBUNTU_VERSION"
-fi
+# https://download.swift.org/swift-5.5.2-release/xcode/swift-5.5.2-RELEASE/swift-5.5.2-RELEASE-osx.pkg
+# https://download.swift.org/swift-5.5.2-release/ubuntu1804/swift-5.5.2-RELEASE/swift-5.5.2-RELEASE-ubuntu18.04.tar.gz
+# https://download.swift.org/swift-5.5.2-release/ubuntu2004/swift-5.5.2-RELEASE/swift-5.5.2-RELEASE-ubuntu20.04.tar.gz
 
-TOOLCHAIN_TAR="$TOOLCHAIN_PATH.tar.gz"
-TOOLCHAIN_SIG="$TOOLCHAIN_TAR.sig"
-TOOLCHAIN_TAR_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_TAR"
-TOOLCHAIN_SIG_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_SIG"
+# https://download.swift.org/development/xcode/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-osx.pkg
+# https://download.swift.org/development/ubuntu1804/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu18.04.tar.gz
+# https://download.swift.org/development/ubuntu1804/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu18.04.tar.gz.sig
+# https://download.swift.org/development/ubuntu2004/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu20.04.tar.gz
+# https://download.swift.org/development/ubuntu2004/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu20.04.tar.gz.sig
 
-echo "Installing system dependencies for '$UBUNTU_VERSION' 📦"
-sudo apt-get update
-if [ $UBUNTU_VERSION == "18.04" ]; then
-    sudo apt-get install \
-    binutils git libc6-dev libcurl4 libedit2 libgcc-5-dev libpython2.7 libsqlite3-0 libstdc++-5-dev libxml2 \
-    pkg-config tzdata zlib1g-dev
-elif [ $UBUNTU_VERSION == "20.04" ]; then
-    sudo apt-get install \
-    binutils git gnupg2 libc6-dev libcurl4 libedit2 libgcc-9-dev libpython2.7 libsqlite3-0 libstdc++-9-dev libxml2 \
-    libz3-dev pkg-config tzdata uuid-dev zlib1g-dev
+# $SWIFT_VERSION: 5.5 || swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a
+
+KERNEL=$(uname)
+if [[ $KERNEL == "Darwin" ]]; then
+    IS_MACOS=true
+elif [[ $KERNEL == "Linux" ]]; then
+    IS_LINUX=true
+    UBUNTU_VERSION=$(lsb_release -rs)
 else
-    echo "No Swift Toolchain available for Ubuntu version '$UBUNTU_VERSION'."
-    echo "Visit https://swift.org/download for more information."
+    echo "Unsupported kernel '$KERNEL' ☠️"
     exit 1;
 fi
 
-if [ -d "/usr/share/swift-toolchain" ]; then
-    echo "Toolchain already exists, skipping download ✅"
-else
-    echo "Reading toolchain version from .swift-version 📄"
-    echo "Detected Swift toolchain version '$(cat .swift-version)' 📄"
+release_name () {
+    if [[ $SWIFT_VERSION == swift-DEVELOPMENT-SNAPSHOT* ]]; then
+        RELEASE_NAME=$SWIFT_VERSION
+    else
+        RELEASE_NAME=swift-$SWIFT_VERSION-RELEASE
+    fi
 
-    echo "Downloading Swift toolchain ☁️"
-    wget $TOOLCHAIN_TAR_URL
+    echo $RELEASE_NAME
+}
 
+download_file () {
+    FILETYPE=$1
+
+    if [ $IS_MACOS ]; then
+        ALT_PLATFORM=osx
+    elif [ $IS_LINUX ]; then
+        ALT_PLATFORM=ubuntu$UBUNTU_VERSION
+    fi
+
+    RETURN_VALUE=$(release_name)-$ALT_PLATFORM
+
+    if [ $FILETYPE ]; then
+        RETURN_VALUE=$RETURN_VALUE.$FILETYPE
+    fi
+
+    echo $RETURN_VALUE
+}
+
+download_url () {
+    DOWNLOAD_BASE_URL=https://download.swift.org
+    FILETYPE=$1
+
+    if [[ $SWIFT_VERSION == swift-DEVELOPMENT-SNAPSHOT* ]]; then
+        FOLDER=development
+    else
+        FOLDER=swift-$SWIFT_VERSION-release
+    fi
+
+    if [ $IS_MACOS ]; then
+        PLATFORM=xcode
+    elif [ $IS_LINUX ]; then
+        PLATFORM=ubuntu${UBUNTU_VERSION//[.]/}
+    fi
+
+    echo $DOWNLOAD_BASE_URL/$FOLDER/$PLATFORM/$(release_name)/$(download_file $FILETYPE)
+}
+
+if [ $IS_LINUX ]; then
+    echo "Installing system dependencies for '$UBUNTU_VERSION' 📦"
+    sudo apt-get update
+    if [ $UBUNTU_VERSION == "18.04" ]; then
+        sudo apt-get install \
+        binutils git libc6-dev libcurl4 libedit2 libgcc-5-dev libpython2.7 libsqlite3-0 libstdc++-5-dev libxml2 \
+        pkg-config tzdata zlib1g-dev
+    elif [ $UBUNTU_VERSION == "20.04" ]; then
+        sudo apt-get install \
+        binutils git gnupg2 libc6-dev libcurl4 libedit2 libgcc-9-dev libpython2.7 libsqlite3-0 libstdc++-9-dev libxml2 \
+        libz3-dev pkg-config tzdata uuid-dev zlib1g-dev
+    else
+        echo "No Swift Toolchain available for Ubuntu version '$UBUNTU_VERSION'."
+        echo "Visit https://swift.org/download for more information."
+        exit 1
+    fi
+fi
+
+if [ $IS_MACOS ]; then
+    TOOLCHAIN_URL=$(download_url pkg)
+elif [ $IS_LINUX ]; then
+    TOOLCHAIN_URL=$(download_url tar.gz)
+    TOOLCHAIN_SIG_URL=$(download_url tar.gz.sig)
+fi
+
+echo "Downloading Swift toolchain ☁️"
+wget $TOOLCHAIN_URL
+
+if [ $IS_LINUX ]; then
     echo "Verifying Swift toolchain 🔑"
     wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
     wget $TOOLCHAIN_SIG_URL
-    gpg --verify $TOOLCHAIN_SIG
+    gpg --verify $(download_file tar.gz.sig)
 
     echo "Installing Swift toolchain 💻"
-    tar xzf $TOOLCHAIN_TAR
+    tar xzf $(download_file tar.gz)
+    ls
+    mkdir /opt/swift-toolchains
+    mv $(download_file) /opt/swift-toolchains/$(release_name).xctoolchain
 
-    mv $TOOLCHAIN_PATH /usr/share/swift-toolchain
-    echo "Successfully installed Swift toolchain 🎉"
+    PATH=/opt/swift-toolchains/$(release_name).xctoolchain/usr/bin:${PATH}
+elif [ $IS_MACOS ]; then
+    echo "Installing Swift toolchain 💻"
+    sudo installer -pkg $(download_file pkg) -target /
+
+    PATH=/Library/Developer/Toolchains/$(release_name).xctoolchain/usr/bin:"${PATH}"
 fi
-
-export PATH=/usr/share/swift-toolchain/usr/bin:${PATH}
 echo "PATH=$PATH" >> $GITHUB_ENV
+
+echo "Successfully installed Swift toolchain 🎉"

--- a/install-swift.sh
+++ b/install-swift.sh
@@ -13,6 +13,7 @@ install_swift () {
     else
         download_toolchain
         if_linux_verify_signature
+        if_macos_run_installer
     fi
 
     if_linux_install_system_dependencies
@@ -82,6 +83,17 @@ if_linux_verify_signature () {
     gpg --verify $(download_file tar.gz.sig)
 }
 
+if_macos_run_installer () {
+    if ! [[ $IS_MACOS ]]; then
+        return 0;
+    fi
+
+    echo "Running installer 💻"
+    TOOLCHAIN=$(release_name).xctoolchain
+    xattr -dr com.apple.quarantine $(download_file pkg)
+    installer -pkg $(download_file pkg) -target CurrentUserHomeDirectory
+}
+
 install_toolchain () {
     echo "Installing Swift toolchain 💻"
 
@@ -89,11 +101,8 @@ install_toolchain () {
         tar xzf $(download_file tar.gz)
         mkdir $(toolchains_path)
         mv $(download_file) $(toolchain_path)
-    elif [ $IS_MACOS ]; then
-        TOOLCHAIN=$(release_name).xctoolchain
-        TOOLCHAINS_PATH=/Library/Developer/Toolchains
-        sudo installer -pkg $(download_file pkg) -target /
     fi
+
     PATH=$(toolchain_path)/usr/bin:${PATH}
     echo "PATH=$PATH" >> $GITHUB_ENV
 }
@@ -126,7 +135,7 @@ toolchains_path () {
     if [ $IS_LINUX ]; then
         echo /opt/swift-toolchains
     elif [ $IS_MACOS ]; then
-        echo /Library/Developer/Toolchains
+        echo ${HOME}/Library/Developer/Toolchains
     fi
 }
 


### PR DESCRIPTION
## Changes
- Now also supports macOS
- CI now also tests on macOS
- Split script into step-like functions invoked from `install_swift` main function

Closes #5.