### PR TITLE
Support upcoming release snapshots

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,12 +9,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
-        swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a]
+        swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a, swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-09-a]
         include:
           - swift: 5.5
             expected-version-string: "Swift version 5.5 (swift-5.5-RELEASE)"
           - swift: swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a
             expected-version-string: "Swift version 5.6-dev (LLVM 7b20e61dd04138a, Swift 9438cf6b2e83c5f)"
+          - swift: swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-09-a
+            expected-version-string: "Swift version 5.6-dev (LLVM 143f1389db63309, Swift 00f7685e0968cbb)"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This action allows installing Swift toolchains, with support for both release an
 
 ### Inputs
 
-- `version` - The Swift version you want to install. This may either be a release version like `5.5`, or a development
-snapshot like `swift-DEVELOPMENT-SNAPSHOT-2021-11-12-a`.
+- `version` - The Swift version you want to install. This may either be a release version like `5.5`, a trunk
+development snapshot like `swift-DEVELOPMENT-SNAPSHOT-2021-11-12-a`, or a snapshot of the upcoming release, e.g.
+`swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-09-a`.
 
 ### Example
 
@@ -37,7 +38,7 @@ jobs:
     name: Run Tests
     strategy:
       matrix:
-        swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2021-11-12-a]
+        swift: [5.5, swift-DEVELOPMENT-SNAPSHOT-2021-11-12-a, swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-09-a]
         os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
         fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/action.yaml
+++ b/action.yaml
@@ -16,7 +16,7 @@ runs:
 
       SWIFT_VERSION=${{ inputs.version }}
 
-      if [[ $SWIFT_VERSION == swift-DEVELOPMENT-SNAPSHOT* ]]; then
+      if [[ $SWIFT_VERSION == *DEVELOPMENT-SNAPSHOT* ]]; then
           RELEASE_NAME=$SWIFT_VERSION
       else
           RELEASE_NAME=swift-$SWIFT_VERSION-RELEASE

--- a/install-swift.sh
+++ b/install-swift.sh
@@ -116,12 +116,19 @@ install_toolchain () {
 # https://download.swift.org/swift-5.5.2-release/ubuntu1804/swift-5.5.2-RELEASE/swift-5.5.2-RELEASE-ubuntu18.04.tar.gz
 # https://download.swift.org/swift-5.5.2-release/ubuntu2004/swift-5.5.2-RELEASE/swift-5.5.2-RELEASE-ubuntu20.04.tar.gz
 
-# Example development snapshot URLs
+# Example trunk development snapshot URLs
 # https://download.swift.org/development/xcode/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-osx.pkg
 # https://download.swift.org/development/ubuntu1804/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu18.04.tar.gz
 # https://download.swift.org/development/ubuntu1804/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu18.04.tar.gz.sig
 # https://download.swift.org/development/ubuntu2004/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu20.04.tar.gz
 # https://download.swift.org/development/ubuntu2004/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a/swift-DEVELOPMENT-SNAPSHOT-2022-01-09-a-ubuntu20.04.tar.gz.sig
+
+# Example version-specific development snapshot URLs
+# https://download.swift.org/swift-5.6-branch/xcode/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a-osx.pkg
+# https://download.swift.org/swift-5.6-branch/ubuntu1804/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a-ubuntu18.04.tar.gz
+# https://download.swift.org/swift-5.6-branch/ubuntu1804/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a-ubuntu18.04.tar.gz.sig
+# https://download.swift.org/swift-5.6-branch/ubuntu2004/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a-ubuntu20.04.tar.gz
+# https://download.swift.org/swift-5.6-branch/ubuntu2004/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a/swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-11-a-ubuntu20.04.tar.gz.sig
 
 toolchain_path () {
     if [ $IS_LINUX ]; then
@@ -140,7 +147,7 @@ toolchains_path () {
 }
 
 release_name () {
-    if [[ $SWIFT_VERSION == swift-DEVELOPMENT-SNAPSHOT* ]]; then
+    if [[ $SWIFT_VERSION == *DEVELOPMENT-SNAPSHOT* ]]; then
         RELEASE_NAME=$SWIFT_VERSION
     else
         RELEASE_NAME=swift-$SWIFT_VERSION-RELEASE
@@ -173,6 +180,8 @@ download_url () {
 
     if [[ $SWIFT_VERSION == swift-DEVELOPMENT-SNAPSHOT* ]]; then
         FOLDER=development
+    elif [[ $SWIFT_VERSION =~ swift-(.*)-DEVELOPMENT-SNAPSHOT-.* ]]; then
+        FOLDER=swift-${BASH_REMATCH[1]}-branch
     else
         FOLDER=swift-$SWIFT_VERSION-release
     fi


### PR DESCRIPTION
## Changes

- Installing [upcoming release snapshots](https://www.swift.org/download/#swift-56-development-main) (e.g. `swift-5.6-DEVELOPMENT-SNAPSHOT-2022-01-09-a`) is now supported.

Closes #13.