### PR TITLE
Bump cache to v4.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest]
         swift:
           [
             5.7,

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,7 @@ runs:
 
   - name: Cache Swift Toolchain
     id: swift-toolchain-cache
-    uses: actions/cache@v3.3.1
+    uses: actions/cache@v4.2.0
     with:
       path: ${{ env.TOOLCHAIN_CACHE_PATH }}
       key: ${{ env.TOOLCHAIN_CACHE_KEY }}


### PR DESCRIPTION
https://github.com/actions/cache?tab=readme-ov-file#%EF%B8%8F-important-changes

> We are deprecating some versions of this action. We recommend upgrading to version v4 or v3 as soon as possible before February 1st, 2025.

The action is currently failing, and this PR should address the issue.