### PR TITLE
Update supported Ubuntu images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-latest]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest]
         swift:
           [
             5.7,


### PR DESCRIPTION
18.04 is gone, 24.04 is here.